### PR TITLE
Do not show Filmot video metadata when requiring login for age-gated videos

### DIFF
--- a/filmot-title-restorer.user.js
+++ b/filmot-title-restorer.user.js
@@ -79,8 +79,9 @@ function cleanUP() {
 }
 
 function checkIfPrivatedOrRemoved() {
-    var status=window.ytInitialPlayerResponse.playabilityStatus.status;
-    if (status=="ERROR" || status=="LOGIN_REQUIRED") {
+    const playabilityStatus=window.ytInitialPlayerResponse.playabilityStatus;
+    const status=playabilityStatus.status;
+    if (status=="ERROR" || (status=="LOGIN_REQUIRED" && !playabilityStatus.valueOf().desktopLegacyAgeGateReason)) {
         var id=window.ytInitialData.currentVideoEndpoint.watchEndpoint.videoId;
         if (id.length>=11) {
             window.deletedIDs=id;


### PR DESCRIPTION
Under "Sign in to confirm your age" on age-restricted video when not signed in, Filmot video metadata would display if available, as `ytInitialPlayerResponse.playabilityStatus` is equal to "LOGIN_REQUIRED", identically to private videos.

To fix this, on "LOGIN_REQUIRED" the script now also checks if `desktopLegacyAgeGateReason` is set.